### PR TITLE
Implementacion metodo NaivLoopUnrollingTwo

### DIFF
--- a/algoritmos/naiv_loop_unrolling_two.go
+++ b/algoritmos/naiv_loop_unrolling_two.go
@@ -1,0 +1,34 @@
+package algoritmos
+
+func NaivLoopUnrollingTwo(a [][]int, b [][]int) [][]int {
+	resultado := make([][]int, 0)
+
+	if len(b)%2 == 0 {
+		for i := 0; i < len(a); i++ {
+			filaAux := make([]int, 0)
+			for j := 0; j < len(b[i]); j++ {
+				suma := 0
+				for k := 0; k < len(b); k += 2 {
+					suma += (a[i][k] * b[k][j]) + (a[i][k+1] * b[k+1][j])
+				}
+				filaAux = append(filaAux, suma)
+			}
+			resultado = append(resultado, filaAux)
+		}
+	} else {
+		ultimoIndice := len(b) - 1
+		for i := 0; i < len(a); i++ {
+			filaAux := make([]int, 0)
+			for j := 0; j < len(b[i]); j++ {
+				suma := 0
+				for k := 0; k < ultimoIndice; k += 2 {
+					suma += (a[i][k] * b[k][j]) + (a[i][k+1] * b[k+1][j])
+				}
+				filaAux = append(filaAux, suma+(a[i][ultimoIndice]*b[ultimoIndice][j]))
+			}
+			resultado = append(resultado, filaAux)
+		}
+	}
+
+	return resultado
+}

--- a/algoritmos/naiv_loop_unrolling_two_test.go
+++ b/algoritmos/naiv_loop_unrolling_two_test.go
@@ -1,0 +1,33 @@
+package algoritmos_test
+
+import (
+	"generador/algoritmos"
+	"reflect"
+	"testing"
+)
+
+func TestNaivLoopUnrollingTwo(t *testing.T) {
+
+	a := [][]int{
+		{1, 2, 3},
+		{4, 5, 6},
+	}
+
+	b := [][]int{
+		{7, 8},
+		{9, 10},
+		{11, 12},
+	}
+
+	esperado := [][]int{
+		{58, 64},
+		{139, 154},
+	}
+
+	resultado := algoritmos.NaivLoopUnrollingTwo(a, b)
+
+	if !reflect.DeepEqual(resultado, esperado) {
+		t.Error("NaivLoopUnrollingTwo ha fallado")
+	}
+
+}


### PR DESCRIPTION
Buenas.

Se implementó el método de multiplicación NaivLoopUnrollingTwo. Se realizaron dos pruebas de funcionalidad, la primera con el test de una matriz 2x3 y otra 3x2 en el archivo naiv_loop_unrolling_two_test.go, y otro con la matriz "Matriz_1000x1000.json" con un llamado desde el main. Para esta última no se comprobaron los resultados 🙈.

Espero la revisión y autorización para ejecutar el merge sobre la rama develop.

Gracias.