### PR TITLE
Implementacion metodo III_ParallelBlock

### DIFF
--- a/algoritmos/iii_parallel_block.go
+++ b/algoritmos/iii_parallel_block.go
@@ -1,0 +1,36 @@
+package algoritmos
+
+import "sync"
+
+func III_ParallelBlock (a, b [][]int) [][]int {
+	resultado := make([][]int, len(a))
+	size := len(a)
+	bsize := 2
+
+	for i := range resultado {
+		resultado[i] = make([]int, size)
+	}
+
+	var wg sync.WaitGroup
+	for i1 := 0; i1 < size; i1 += bsize {
+		for j1 := 0; j1 < size; j1 += bsize {
+			for k1 := 0; k1 < size; k1 += bsize {
+				wg.Add(1)
+				go func (i1, j1, k1 int) {
+					for i := i1; i < i1 + bsize && i < size; i++ {
+						for j := j1; j < j1 + bsize && j < size; j++ {
+							for k := k1; k < k1 + bsize && k < size; k++ {
+								resultado[i][j] += a[i][k] * b[k][j];
+							};
+						}
+					}
+					wg.Done()
+				}(i1, j1, k1)
+			}
+		}
+	}
+
+	wg.Wait()
+
+	return resultado
+}

--- a/test/iii_parallel_block_test.go
+++ b/test/iii_parallel_block_test.go
@@ -1,0 +1,36 @@
+package test
+
+import (
+	"generador/algoritmos"
+	"reflect"
+	"testing"
+)
+
+func TestIIIParallelBlock(t *testing.T) {
+	a := [][]int{
+		{1, 2, 3, 4},
+		{5, 6, 7, 8},
+		{9, 10, 11, 12},
+		{13, 14, 15, 16},
+	}
+
+	b := [][]int{
+		{17, 18, 19, 20},
+		{21, 22, 23, 24},
+		{25, 26, 27, 28},
+		{29, 30, 31, 32},
+	}
+
+	esperado := [][]int{
+		{250, 260, 270, 280},
+		{618, 644, 670, 696},
+		{986, 1028, 1070, 1112},
+		{1354, 1412, 1470, 1528},
+	}
+
+	resultado := algoritmos.III_ParallelBlock(a, b)
+
+	if !reflect.DeepEqual(resultado, esperado) {
+		t.Errorf("IV_4 ParallelBlock ha fallado")
+	}
+}


### PR DESCRIPTION
Hi.

Se implementó el método de multiplicación III_ParallelBlock. La forma en que se utilizan los hilos quedó igual a la del método IV_ParallelBlock (incluso en el artículo parecen tener las mismas instrucciones). Para validar el funcionamiento del método se realizó una prueba con matrices de dimensiones 4x4.

Espero la revisión y autorización para ejecutar el merge sobre la rama develop.

Gracias.